### PR TITLE
Allow noaho to be pip installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,31 @@
 from distutils.core import setup
 from distutils.extension import Extension
 
-noaho_module = Extension("noaho",
-                         sources = ["noaho/noaho.cpp", "noaho/array-aho.cpp"],
-                         depends = ["noaho/array-aho.h", "noaho/HashMap.h", "noaho/LinearHashTable.h",
-                                    'noaho/noaho.pyx']
-                         )
+noaho_module = Extension(
+    "noaho",
+    sources=["noaho/noaho.cpp", "noaho/array-aho.cpp"],
+    depends=[
+        "noaho/array-aho.h",
+        "noaho/HashMap.h",
+        "noaho/LinearHashTable.h",
+        'noaho/noaho.pyx']
+)
 
 version = "0.9.02"
 
-setup(name = "NoAho",
-      version=version,
-      author="Jeff Donner",
-      author_email="jeffrey.donner@gmail.com",
-      maintainer="Jeff Donner",
-      maintainer_email="jeffrey.donner@gmail.com",
-      url="https://github.com/JDonner/NoAho",
-      download_url="http://pypi.python.org/packages/source/N/NoAho/NoAho-%s.tar.gz" % version,
-      description="Fast, non-overlapping simultaneous multiple keyword search",
-      long_description = open('README.txt').read(),
-      ext_modules = [noaho_module],
-      packages = ['noaho'],
-
-      classifiers = [
+setup(
+    name="NoAho",
+    version=version,
+    author="Jeff Donner",
+    author_email="jeffrey.donner@gmail.com",
+    maintainer="Jeff Donner",
+    maintainer_email="jeffrey.donner@gmail.com",
+    url="https://github.com/JDonner/NoAho",
+    download_url="http://pypi.python.org/packages/source/N/NoAho/NoAho-%s.tar.gz" % version,
+    description="Fast, non-overlapping simultaneous multiple keyword search",
+    long_description=open('README.txt').read(),
+    ext_modules=[noaho_module],
+    classifiers=[
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
         'License :: OSI Approved :: MIT License',
@@ -39,5 +42,5 @@ setup(name = "NoAho",
         'Operating System :: OS Independent',
         "Environment :: Console",
         'Topic :: Text Processing',
-        ]
-      )
+    ]
+)


### PR DESCRIPTION
I tried to install noaho via simple `pip install noaho`. The build + install phase worked perfectly, but the `noaho` module was completely empty: nothing could be imported from it.
This came from the fact that you declared (in the setup.py) that the `noaho` module should be packaged and installed, whereas only the `noaho.so` is of interest.

Pip thus creates a `noaho` folder with an empty `__init__.py` file inside, which will be imported (instead of `noaho.so`) when doing `import noaho`

By removing the `packages=['noaho']` line, pip will not create the `noaho` folder in the virtualenv site-packages directory. Hence, only the egg file and the `noaho.so` file will be found.

The other modifications are just whitespaces.
Signed-off-by: Balthazar Rouberol balthazar.rouberol@mapado.com
